### PR TITLE
Optimize regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ export default function emailRegex(options) {
 	};
 
 	// RFC 5322 (https://datatracker.ietf.org/doc/html/rfc5322)
-	const atext = String.raw`(?:[A-Za-z\d!#$%&'*+\-/=?^_\`{|}~]${options.allowAmpersandEntity ? '|&amp;' : ''})`;
+	const atextInner = String.raw`[A-Za-z\d!#$%&'*+\-/=?^_\`{|}~]`;
+	const atext = options.allowAmpersandEntity ? `(?:${atextInner}|&amp;)` : atextInner;
 	const dquote = '"';
 	const sp = ' ';
 	const htab = String.raw`\u0009`;

--- a/index.js
+++ b/index.js
@@ -10,9 +10,7 @@ export default function emailRegex(options) {
 	const atextInner = String.raw`[A-Za-z\d!#$%&'*+\-/=?^_\`{|}~]`;
 	const atext = options.allowAmpersandEntity ? `(?:${atextInner}|&amp;)` : atextInner;
 	const dquote = '"';
-	const sp = ' ';
-	const htab = String.raw`\u0009`;
-	const wsp = `(?:${sp}|${htab})`;
+	const wsp = String.raw`[ \u0009]`;
 	const cr = String.raw`\u000D`;
 	const lf = String.raw`\u000A`;
 	const obsNoWsCtl = String.raw`(?:[\u0001-\u0008]|\u000B|\u000C|[\u000E-\u001F]|\u007F)`;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export default function emailRegex(options) {
 	const atom = `${atext}+`;
 	const word = `(?:${atom}|${quotedString})`;
 	const dotAtomOrObsLocalPart = String.raw`(?:${word}(?:\.${word})*)`; // Overlap between dot-atom and obs-local-part
-	const localPart = `(?:${quotedString}|${dotAtomOrObsLocalPart})`;
+	const localPart = `(?:${dotAtomOrObsLocalPart}|${quotedString})`;
 	const obsDtext = `(?:${obsNoWsCtl}|${quotedPair})`;
 	const dtext = String.raw`(?:[\u0021-\u005A]|[\u005E-\u007E]|${obsDtext})`;
 	const domainLiteral = String.raw`(?:\[${dtext}*])`;

--- a/index.js
+++ b/index.js
@@ -24,12 +24,12 @@ export default function emailRegex(options) {
 	const quotedString = `(?:${dquote}${qcontent}*${dquote})`;
 	const atom = `${atext}+`;
 	const word = `(?:${atom}|${quotedString})`;
-	const dotAtomOrObsLocalPart = String.raw`(?:${word}(?:\.${word})*)`; // DotAtom and obsLocalPart overlap
+	const dotAtomOrObsLocalPart = String.raw`(?:${word}(?:\.${word})*)`; // Overlap between dot-atom and obs-local-part
 	const localPart = `(?:${quotedString}|${dotAtomOrObsLocalPart})`;
 	const obsDtext = `(?:${obsNoWsCtl}|${quotedPair})`;
 	const dtext = String.raw`(?:[\u0021-\u005A]|[\u005E-\u007E]|${obsDtext})`;
 	const domainLiteral = String.raw`(?:\[${dtext}*])`;
-	const dotAtomOrObsDomain = String.raw`(?:${atom}(?:\.${atom})${options.allowSingleLabelDomain ? '*' : '+'})`; // DotAtom and obsDomain overlap
+	const dotAtomOrObsDomain = String.raw`(?:${atom}(?:\.${atom})${options.allowSingleLabelDomain ? '*' : '+'})`; // Overlap between dot-atom and obs-domain
 	const domain = `(?:${dotAtomOrObsDomain}|${domainLiteral})`;
 	const addrSpec = `${localPart}@${domain}`;
 


### PR DESCRIPTION
Regex size is approximately halved

Notable changes:
- `dot-atom`/`obs-local-part` and `dot-atom`/`obs-domain` are merged because they match the same thing
- Don't match folding white space (FWS) because it is not used in the actual email, [but rather to format the email if it is too long for a single line of an email message](https://stackoverflow.com/a/79701885/8384910). **This technically removes the use case of extracting emails from a large dataset of text data that might contain email messages, if those emails span multiple lines**